### PR TITLE
add support for applying patch to dist-kernels

### DIFF
--- a/sys-kernel/gentoo-kernel-4.14.52
+++ b/sys-kernel/gentoo-kernel-4.14.52
@@ -1,0 +1,1 @@
+gentoo-sources-4.14.52

--- a/sys-kernel/gentoo-kernel-4.14.63-r1
+++ b/sys-kernel/gentoo-kernel-4.14.63-r1
@@ -1,0 +1,1 @@
+gentoo-sources-4.14.63-r1

--- a/sys-kernel/gentoo-kernel-4.14.65
+++ b/sys-kernel/gentoo-kernel-4.14.65
@@ -1,0 +1,1 @@
+gentoo-sources-4.14.65

--- a/sys-kernel/gentoo-kernel-4.14.78
+++ b/sys-kernel/gentoo-kernel-4.14.78
@@ -1,0 +1,1 @@
+gentoo-sources-4.14.78

--- a/sys-kernel/gentoo-kernel-4.14.83
+++ b/sys-kernel/gentoo-kernel-4.14.83
@@ -1,0 +1,1 @@
+gentoo-sources-4.14.83

--- a/sys-kernel/gentoo-kernel-4.19.23
+++ b/sys-kernel/gentoo-kernel-4.19.23
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.23

--- a/sys-kernel/gentoo-kernel-4.19.27-r1
+++ b/sys-kernel/gentoo-kernel-4.19.27-r1
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.27-r1

--- a/sys-kernel/gentoo-kernel-4.19.37
+++ b/sys-kernel/gentoo-kernel-4.19.37
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.37

--- a/sys-kernel/gentoo-kernel-4.19.44
+++ b/sys-kernel/gentoo-kernel-4.19.44
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.44

--- a/sys-kernel/gentoo-kernel-4.19.52
+++ b/sys-kernel/gentoo-kernel-4.19.52
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.52

--- a/sys-kernel/gentoo-kernel-4.19.57
+++ b/sys-kernel/gentoo-kernel-4.19.57
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.57

--- a/sys-kernel/gentoo-kernel-4.19.66
+++ b/sys-kernel/gentoo-kernel-4.19.66
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.66

--- a/sys-kernel/gentoo-kernel-4.19.72
+++ b/sys-kernel/gentoo-kernel-4.19.72
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.72

--- a/sys-kernel/gentoo-kernel-4.19.82
+++ b/sys-kernel/gentoo-kernel-4.19.82
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.82

--- a/sys-kernel/gentoo-kernel-4.19.97
+++ b/sys-kernel/gentoo-kernel-4.19.97
@@ -1,0 +1,1 @@
+gentoo-sources-4.19.97

--- a/sys-kernel/gentoo-kernel-4.9.95
+++ b/sys-kernel/gentoo-kernel-4.9.95
@@ -1,0 +1,1 @@
+gentoo-sources-4.9.95

--- a/sys-kernel/gentoo-kernel-5.4.28
+++ b/sys-kernel/gentoo-kernel-5.4.28
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.28

--- a/sys-kernel/gentoo-kernel-5.4.38
+++ b/sys-kernel/gentoo-kernel-5.4.38
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.38

--- a/sys-kernel/gentoo-kernel-5.4.48
+++ b/sys-kernel/gentoo-kernel-5.4.48
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.48

--- a/sys-kernel/gentoo-kernel-5.4.60
+++ b/sys-kernel/gentoo-kernel-5.4.60
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.60

--- a/sys-kernel/gentoo-kernel-5.4.66
+++ b/sys-kernel/gentoo-kernel-5.4.66
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.66

--- a/sys-kernel/gentoo-kernel-5.4.72
+++ b/sys-kernel/gentoo-kernel-5.4.72
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.72

--- a/sys-kernel/gentoo-kernel-5.4.80
+++ b/sys-kernel/gentoo-kernel-5.4.80
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.80

--- a/sys-kernel/gentoo-kernel-5.4.92
+++ b/sys-kernel/gentoo-kernel-5.4.92
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.92

--- a/sys-kernel/gentoo-kernel-5.4.97
+++ b/sys-kernel/gentoo-kernel-5.4.97
@@ -1,0 +1,1 @@
+gentoo-sources-5.4.97


### PR DESCRIPTION
By adding a symlink for the same version of gentoo-sources to the same version of gentoo-kernel this patch will apply to distribution kernels.