### PR TITLE
Missing symlink for 5.10.27 release and script to automate symlink creation

### DIFF
--- a/make_new_symlink.bash
+++ b/make_new_symlink.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+WORK_DIR="${WORK_DIR:-sys-kernel}"
+
+[ -d "$WORK_DIR" ] && cd "$WORK_DIR"
+
+for rel_src_dir in gentoo-sources-*; do
+    __ln_target="${rel_src_dir/sources/kernel}"
+    [ -L "$__ln_target" ] || ln -sf "$rel_src_dir" "$__ln_target"
+    if [ ! -L "$__ln_target" ]; then
+        printf "Unable to make new symlink for %s\n" "$rel_src_dir"
+        exit 1
+    fi
+done

--- a/sys-kernel/gentoo-kernel-5.10.27
+++ b/sys-kernel/gentoo-kernel-5.10.27
@@ -1,0 +1,1 @@
+gentoo-sources-5.10.27


### PR DESCRIPTION
Sorry missed a release that was on another branch!

* added missing symlink for gentoo-kernel-5.10.27
* added script to create missing symlinks